### PR TITLE
fix(provider): always include the API response contents into the error messages

### DIFF
--- a/hivelocity/data_source_bare_metal_device.go
+++ b/hivelocity/data_source_bare_metal_device.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	swagger "github.com/hivelocity/terraform-provider-hivelocity/hivelocity-client-go"
 )
 
 func dataSourceBareMetalDevice() *schema.Resource {
@@ -105,7 +107,8 @@ func dataSourceBareMetalDeviceRead(ctx context.Context, d *schema.ResourceData, 
 
 	bareMetalDeviceInfo, _, err := hv.client.BareMetalDevicesApi.GetBareMetalDeviceResource(hv.auth, nil)
 	if err != nil {
-		return diag.FromErr(err)
+		myErr := err.(swagger.GenericSwaggerError)
+		return diag.Errorf("GET /bare-metal-devices failed! (%s)\n\n %s", err, myErr.Body())
 	}
 
 	jsonProductInfo, err := json.Marshal(bareMetalDeviceInfo)

--- a/hivelocity/data_source_device.go
+++ b/hivelocity/data_source_device.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	swagger "github.com/hivelocity/terraform-provider-hivelocity/hivelocity-client-go"
 )
 
 func buildDeviceSchema() map[string]*schema.Schema {
@@ -82,7 +84,7 @@ func buildDeviceSchema() map[string]*schema.Schema {
 func dataSourceDevice() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceDeviceRead,
-		Schema: buildDeviceSchema(),
+		Schema:      buildDeviceSchema(),
 	}
 }
 
@@ -94,7 +96,8 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 	hivelocityDevices, _, err := hv.client.DeviceApi.GetDeviceResource(hv.auth, nil)
 	if err != nil {
-		return diag.FromErr(err)
+		myErr := err.(swagger.GenericSwaggerError)
+		return diag.Errorf("GET /device failed! (%s)\n\n %s", err, myErr.Body())
 	}
 
 	jsonDevices, err := json.Marshal(hivelocityDevices)

--- a/hivelocity/data_source_device_initial_creds.go
+++ b/hivelocity/data_source_device_initial_creds.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	swagger "github.com/hivelocity/terraform-provider-hivelocity/hivelocity-client-go"
 )
 
 func buildDeviceInitialCredsSchema() map[string]*schema.Schema {
@@ -50,7 +51,8 @@ func dataSourceDeviceInitialCredsRead(ctx context.Context, d *schema.ResourceDat
 	deviceID := int32(d.Get("device_id").(int))
 	hivelocityInitialCreds, _, err := hv.client.DeviceApi.GetInitialCredsIdResource(hv.auth, deviceID, nil)
 	if err != nil {
-		return diag.FromErr(err)
+		myErr := err.(swagger.GenericSwaggerError)
+		return diag.Errorf("GET /device/%d/initial-creds failed! (%s)\n\n %s", deviceID, err, myErr.Body())
 	}
 
 	jsonInitialCreds, err := json.Marshal(hivelocityInitialCreds)

--- a/hivelocity/data_source_product.go
+++ b/hivelocity/data_source_product.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	swagger "github.com/hivelocity/terraform-provider-hivelocity/hivelocity-client-go"
 )
 
 func dataSourceProduct() *schema.Resource {
@@ -58,7 +59,8 @@ func dataSourceProductRead(ctx context.Context, d *schema.ResourceData, m interf
 
 	productInfo, _, err := hv.client.ProductApi.GetProductListResource(hv.auth, nil)
 	if err != nil {
-		return diag.FromErr(err)
+		myErr := err.(swagger.GenericSwaggerError)
+		return diag.Errorf("GET /product/list failed! (%s)\n\n %s", err, myErr.Body())
 	}
 
 	jsonProductInfo, err := json.Marshal(productInfo)

--- a/hivelocity/resource_ssh_key.go
+++ b/hivelocity/resource_ssh_key.go
@@ -71,7 +71,8 @@ func resourceSSHKeyRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	SSHKeyResponse, _, err := hv.client.SshKeyApi.GetSshKeyIdResource(hv.auth, int32(SSHKeyID), nil)
 	if err != nil {
-		return diag.FromErr(err)
+		myErr := err.(swagger.GenericSwaggerError)
+		return diag.Errorf("GET /ssh_key/%d failed! (%s)\n\n %s", SSHKeyID, err, myErr.Body())
 	}
 
 	d.Set("ssh_key_id", SSHKeyResponse.SshKeyId)


### PR DESCRIPTION
This change ensures that details about specific API errors are always going to be printed out to the user.